### PR TITLE
Fix get_order_detail bug by removing slash

### DIFF
--- a/kucoin/client.py
+++ b/kucoin/client.py
@@ -1541,7 +1541,7 @@ class Client(object):
         if order_id:
             data['orderOid'] = order_id
 
-        return self._get('/order/detail', True, data=data)
+        return self._get('order/detail', True, data=data)
 
     # Market Endpoints
 


### PR DESCRIPTION
The endpoint in self._get for get_order_details had a slash at the beginning. When creating the full path, it returned /v1//order/detail instead of /v1/order/detail. 

Fix is just to remove the slash to conform with other methods.