### PR TITLE
fixing send_ping never called (closes #56)

### DIFF
--- a/kucoin/asyncio/websockets.py
+++ b/kucoin/asyncio/websockets.py
@@ -33,7 +33,7 @@ class ReconnectingWebsocket:
         self._connect()
 
     def _connect(self):
-        self._conn = asyncio.ensure_future(self._run(),loop=self._loop)
+        self._conn = asyncio.ensure_future(self._run(), loop=self._loop)
 
     async def _run(self):
 


### PR DESCRIPTION
The former implementation always called `ReconnectingWebsocket's ``send_ping `method if no update message was received from kucoin for 9 seconds. If this is not the case (i.e. regular messages from kucoin) Kucoin disconnects the websocket after 1 minute because no ping was sent.  `ReconnectingWebsocket's `run loop then receives a connection closed error and reconnects, which means some messages until reconnection might get lost and reconnecting is also inefficient.
I changed the way `send_ping `is called correspondingly to assure that it is sent every 9 seconds, regardless of the amount of received message.