### PR TITLE
Accommodate changes to the inner-transfer endpoint

### DIFF
--- a/kucoin/client.py
+++ b/kucoin/client.py
@@ -871,7 +871,7 @@ class Client(object):
 
         """
 
-        return self._delete('withdrawals/{}'.format(withdrawal_id), True)
+        return self._delete('v1/withdrawals/{}'.format(withdrawal_id), True)
 
     # Order Endpoints
 
@@ -1072,7 +1072,7 @@ class Client(object):
 
         """
 
-        return self._delete('orders/{}'.format(order_id), True)
+        return self._delete('v1/orders/{}'.format(order_id), True)
 
     def cancel_all_orders(self, symbol=None):
         """Cancel all orders
@@ -1099,7 +1099,7 @@ class Client(object):
         data = {}
         if symbol is not None:
             data['symbol'] = symbol
-        return self._delete('orders', True, data=data)
+        return self._delete('v1/orders', True, data=data)
 
     def get_orders(self, symbol=None, status=None, side=None, order_type=None,
                    start=None, end=None, page=None, limit=None):


### PR DESCRIPTION
The inner-transfer endpoint has been changed with new arguments. Additionally the endpoint moved to /api/v2/accounts/inner-transfer while all other endpoints are still at v1.
This breaks the system used until now to prepend all endpoints with the current version. Therefore I removed that and included the version into each endpoint string.