### PR TITLE
fix get_withdrawal_quotas args

### DIFF
--- a/kucoin/client.py
+++ b/kucoin/client.py
@@ -768,10 +768,13 @@ class Client(object):
 
         :param currency: Name of currency
         :type currency: string
+        :param chain: Name of chain
+        :type chain: string
 
         .. code:: python
 
             quotas = client.get_withdrawal_quotas('ETH')
+            quotas = client.get_withdrawal_quotas('ETH', 'ERC20')
 
         :returns: ApiResponse
 
@@ -795,8 +798,9 @@ class Client(object):
 
         data = {
             'currency': currency,
-            'chain': chain,
         }
+        if chain:
+            data['chain'] = chain
 
         return self._get('withdrawals/quotas', True, data=data)
 

--- a/kucoin/client.py
+++ b/kucoin/client.py
@@ -761,7 +761,7 @@ class Client(object):
 
         return self._get('withdrawals', True, data=data)
 
-    def get_withdrawal_quotas(self, currency):
+    def get_withdrawal_quotas(self, currency, chain=None):
         """Get withdrawal quotas for a currency
 
         https://docs.kucoin.com/#get-withdrawal-quotas
@@ -794,7 +794,8 @@ class Client(object):
         """
 
         data = {
-            'currency': currency
+            'currency': currency,
+            'chain': chain,
         }
 
         return self._get('withdrawals/quotas', True, data=data)


### PR DESCRIPTION


According to the official docs ([link](https://docs.kucoin.com/#get-withdrawal-quotas)), withdrawal quotas method requires optional chain arg (especially for USDT which use TRC20 chain a lot). 

Added optional argument in wrapper function